### PR TITLE
Exploring use cases for grouping imports under `index.js`

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -1,2 +1,1 @@
-import '../imports/startup/client/useraccounts-configuration.js';
-import '../imports/startup/client/routes.js';
+import '/imports/startup/client'

--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -1,0 +1,2 @@
+import './useraccounts-configuration.js';
+import './routes.js';

--- a/imports/startup/server/index.js
+++ b/imports/startup/server/index.js
@@ -1,0 +1,12 @@
+// This defines a starting set of data to be loaded if the app is loaded with an empty db.
+import './fixtures.js';
+
+// This file configures the Accounts package to define the UI of the reset password email.
+import './reset-password-email.js';
+
+// Set up some rate limiting and other important security settings.
+import './security.js';
+
+// This defines all the collections, publications and methods that the application provides
+// as an API to the client.
+import './register-api.js';

--- a/server/main.js
+++ b/server/main.js
@@ -1,12 +1,1 @@
-// This defines a starting set of data to be loaded if the app is loaded with an empty db.
-import '../imports/startup/server/fixtures.js';
-
-// This file configures the Accounts package to define the UI of the reset password email.
-import '../imports/startup/server/reset-password-email.js';
-
-// Set up some rate limiting and other important security settings.
-import '../imports/startup/server/security.js';
-
-// This defines all the collections, publications and methods that the application provides
-// as an API to the client.
-import '../imports/startup/server/register-api.js';
+import '/imports/startup/server';


### PR DESCRIPTION
Ref. #84 

The simplest use case I could find for grouping imports within `index.js` was by moving `/server/main.js` and `/client/main.js` imports close to the startup files they require.

Still exploring a better structure for `/imports/api`. It might make sense to do something like `import "/imports/api/list";` and have everything pertaining to Lists, i.e. `lists.js` and `methods.js`, included together. We don't presently do this in our app.