### PR TITLE
Add ESLint-plugin-Meteor

### DIFF
--- a/imports/startup/client/routes.app-test.js
+++ b/imports/startup/client/routes.app-test.js
@@ -53,7 +53,7 @@ if (Meteor.isClient) {
 
           // Wait for all subscriptions triggered by this route to complete
           waitForSubscriptions(catchAsync(done, () => {
-            assert.equal(Todos.find({listId: list._id}).count(), 3);
+            assert.equal(Todos.find({ listId: list._id }).count(), 3);
             done();
           }));
         }));

--- a/imports/startup/client/routes.js
+++ b/imports/startup/client/routes.js
@@ -1,9 +1,5 @@
 import { Meteor } from 'meteor/meteor';
 
-if (Meteor.isTest) {
-  return;
-}
-
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { BlazeLayout } from 'meteor/kadira:blaze-layout';
 import { AccountsTemplates } from 'meteor/useraccounts:core';
@@ -17,40 +13,42 @@ import '../../ui/pages/app-not-found.js';
 // Import to override accounts templates
 import '../../ui/accounts/accounts-templates.js';
 
-FlowRouter.route('/lists/:_id', {
-  name: 'Lists.show',
-  action() {
-    BlazeLayout.render('App_body', { main: 'Lists_show_page' });
-  },
-});
+if (!Meteor.isTest) {
+  FlowRouter.route('/lists/:_id', {
+    name: 'Lists.show',
+    action() {
+      BlazeLayout.render('App_body', { main: 'Lists_show_page' });
+    },
+  });
 
-FlowRouter.route('/', {
-  name: 'App.home',
-  action() {
-    BlazeLayout.render('App_body', { main: 'app_rootRedirector' });
-  },
-});
+  FlowRouter.route('/', {
+    name: 'App.home',
+    action() {
+      BlazeLayout.render('App_body', { main: 'app_rootRedirector' });
+    },
+  });
 
-// the App_notFound template is used for unknown routes and missing lists
-FlowRouter.notFound = {
-  action() {
-    BlazeLayout.render('App_body', { main: 'App_notFound' });
-  },
-};
+  // the App_notFound template is used for unknown routes and missing lists
+  FlowRouter.notFound = {
+    action() {
+      BlazeLayout.render('App_body', { main: 'App_notFound' });
+    },
+  };
 
-AccountsTemplates.configureRoute('signIn', {
-  name: 'signin',
-  path: '/signin',
-});
+  AccountsTemplates.configureRoute('signIn', {
+    name: 'signin',
+    path: '/signin',
+  });
 
-AccountsTemplates.configureRoute('signUp', {
-  name: 'join',
-  path: '/join',
-});
+  AccountsTemplates.configureRoute('signUp', {
+    name: 'join',
+    path: '/join',
+  });
 
-AccountsTemplates.configureRoute('forgotPwd');
+  AccountsTemplates.configureRoute('forgotPwd');
 
-AccountsTemplates.configureRoute('resetPwd', {
-  name: 'resetPwd',
-  path: '/reset-password',
-});
+  AccountsTemplates.configureRoute('resetPwd', {
+    name: 'resetPwd',
+    path: '/reset-password',
+  });
+}

--- a/imports/ui/components/lists-show.js
+++ b/imports/ui/components/lists-show.js
@@ -58,7 +58,7 @@ Template.Lists_show.onCreated(function listShowOnCreated() {
     Tracker.flush();
     // TODO -- I think velocity introduces a timeout before actually setting opacity on the
     //   element, so I can't focus it for a moment.
-    Meteor.setTimeout(() => {
+    Meteor.defer(() => {
       this.$('.js-edit-form input[type=text]').focus();
     });
   };

--- a/imports/ui/pages/root-redirector.js
+++ b/imports/ui/pages/root-redirector.js
@@ -8,7 +8,7 @@ import './root-redirector.html';
 Template.app_rootRedirector.onCreated(() => {
   // We need to set a timeout here so that we don't redirect from inside a redirection
   //   which is a no-no in FR.
-  Meteor.setTimeout(() => {
+  Meteor.defer(() => {
     FlowRouter.go('Lists.show', Lists.findOne());
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,19 +1,38 @@
 {
   "scripts": {
+    "pretest": "npm run lint",
     "test": "meteor test --driver-package avital:mocha",
     "test-app": "meteor test --full-app --driver-package avital:mocha",
-    "lint": "eslint . || true",
+    "lint": "eslint .",
     "chimp-watch": "node_modules/.bin/chimp --ddp=http://localhost:3000 --watch --mocha --path=tests"
   },
   "devDependencies": {
-    "chimp": "^0.30.0",
     "autoprefixer": "^6.3.1",
-    "faker": "^3.0.1",
-    "eslint": "^1.10.3",
-    "eslint-config-airbnb": "^5.0.1"
+    "chimp": "^0.30.0",
+    "eslint": "^2.3.0",
+    "eslint-config-airbnb": "6.1.0",
+    "eslint-plugin-meteor": "3.0.1",
+    "faker": "^3.0.1"
   },
   "eslintConfig": {
-    "extends": "airbnb/base"
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module"
+    },
+    "plugins": [
+      "meteor"
+    ],
+    "extends": [
+      "airbnb/base",
+      "plugin:meteor/recommended"
+    ],
+    "rules": {
+      "meteor/eventmap-params": [2, {
+        "eventParamName": "event",
+        "templateInstanceParamName": "instance"
+      }],
+      "meteor/template-names": [0]
+    }
   },
   "postcss": {
     "plugins": {


### PR DESCRIPTION
This PR adds [ESLint-plugin-Meteor](https://github.com/dferber90/eslint-plugin-meteor).

**Changes**
- adds ESLint-plugin-Meteor
- resolve surfaced issues
- upgrade ESLint to v2
- upgrade ESLint-config-AirBnB to v6
- add lint script as pretest
- remove hack to always succeed linter

**Potential problems**
I haven't tested the effects of replacing `Meteor.setTimeout(.., 0)` with `Meteor.defer(..)`. This could potentially break some things.

In `imports/startup/client/routes.js`, I had to wrap everything in `if (Meteor.isTest)`. The current syntax was invalid for two reasons:
1) all import statements have to be at the top of the file, but there was this if-block in between
2) returning from outside of a function is illegal


**Open questions**
There is a rule in ESLint-plugin-Meteor which forces a naming convention for templates. I'm not familiar with the convention this project uses, but I've seen it a lot in official Meteor examples. I'd like to integrate that as a rule as well in case MDG keeps on embracing it. Personally, I'm more of a fan of camel-case, because the variables in JS are in camel-case as well. And when a Template is accessed from JS you use `Template.templateName`, so it fits. Otherwise you’d have to use `Template.Template_name` which is different from all other variables/property names for no obvious reason (at least for me). What's the reason behind the current naming convention?

---
To read up on linting and ESLint-plugin-Meteor, you can read [this article](https://medium.com/@dferber90/linting-meteor-8f229ebc7942).