### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/mobile-config.js
+++ b/mobile-config.js
@@ -12,13 +12,11 @@ App.info({
 
 App.icons({
   // iOS
-  'iphone': 'resources/icons/icon-60x60.png',
   'iphone_2x': 'resources/icons/icon-60x60@2x.png',
   'ipad': 'resources/icons/icon-76x76.png',
   'ipad_2x': 'resources/icons/icon-76x76@2x.png',
 
   // Android
-  'android_ldpi': 'resources/icons/icon-36x36.png',
   'android_mdpi': 'resources/icons/icon-48x48.png',
   'android_hdpi': 'resources/icons/icon-72x72.png',
   'android_xhdpi': 'resources/icons/icon-96x96.png',
@@ -26,7 +24,6 @@ App.icons({
 
 App.launchScreens({
   // iOS
-  'iphone': 'resources/splash/splash-320x480.png',
   'iphone_2x': 'resources/splash/splash-320x480@2x.png',
   'iphone5': 'resources/splash/splash-320x568@2x.png',
   'ipad_portrait': 'resources/splash/splash-768x1024.png',
@@ -35,8 +32,6 @@ App.launchScreens({
   'ipad_landscape_2x': 'resources/splash/splash-1024x768@2x.png',
 
   // Android
-  'android_ldpi_portrait': 'resources/splash/splash-200x320.png',
-  'android_ldpi_landscape': 'resources/splash/splash-320x200.png',
   'android_mdpi_portrait': 'resources/splash/splash-320x480.png',
   'android_mdpi_landscape': 'resources/splash/splash-480x320.png',
   'android_hdpi_portrait': 'resources/splash/splash-480x800.png',


### PR DESCRIPTION
These lines cause deprecation warnings when running on mobile e.g.`meteor run android`

I am not sure if several of the .png files in the resources folder can safely be removed.