### PR TITLE
Remove standard-minifier-css to fix build

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -57,4 +57,3 @@ stub-collections
 xolvio:cleaner
 dispatch:mocha-phantomjs
 practicalmeteor:mocha@2.1.1-rc.1
-standard-minifier-css

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -102,7 +102,6 @@ simple:rest-json-error-handler@1.0.1
 spacebars@1.0.10
 spacebars-compiler@1.0.10
 srp@1.0.7
-standard-minifier-css@1.0.5
 standard-minifier-js@1.0.5
 static-html@1.0.6
 stub-collections@0.0.1


### PR DESCRIPTION
I just realised that I missed one error in the previous PR - a package called "standard-minifier-css" was added for some reason and broke the build (see #108). Now all should be fine.