### PR TITLE
Fix two bugs related to editing a list's name

### DIFF
--- a/imports/ui/components/lists-show.html
+++ b/imports/ui/components/lists-show.html
@@ -2,7 +2,7 @@
   <div class="page lists-show">
     <nav class="js-title-nav">
       {{#momentum plugin="fade"}}
-        {{#if instance.state.get 'editing'}}
+        {{#if editing}}
           <form class="js-edit-form list-edit-form">
             <input type="text" name="name" value="{{name}}">
             <div class="nav-group right">

--- a/imports/ui/components/lists-show.js
+++ b/imports/ui/components/lists-show.js
@@ -45,10 +45,12 @@ Template.Lists_show.onCreated(function listShowOnCreated() {
   this.saveList = () => {
     this.state.set('editing', false);
 
-    updateName.call({
-      listId: this.data.list()._id,
-      newName: this.$('[name=name]').val(),
-    }, displayError);
+    if (this.$('[name=name]').val().trim()) {
+      updateName.call({
+        listId: this.data.list()._id,
+        newName: this.$('[name=name]').val(),
+      }, displayError);
+    }
   };
 
   this.editList = () => {
@@ -99,6 +101,10 @@ Template.Lists_show.helpers({
         instance.state.set('editingTodo', editing ? todo._id : false);
       },
     };
+  },
+  editing() {
+    const instance = Template.instance();
+    return instance.state.get('editing');
   },
 });
 


### PR DESCRIPTION
The 'editing' helper function fixes https://github.com/meteor/todos/issues/106 — `instance.state.get` isn't available from the template, so the helper performs the same function.  

Also, saving an empty list, or a list of all whitespace, produces an ugly 400 alert message.  Wrapping the `updateName` function in the check makes sure there is content in the list name before saving, and if not then `saveList` produces the same result as clicking the cancel button.