### PR TITLE
Wrap common 'meteor' command usage by configuring 'npm start'

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "pretest": "npm run lint --silent",
     "test": "meteor test --once --driver-package dispatch:mocha-phantomjs",
     "test-watch": "meteor test --driver-package practicalmeteor:mocha",
-    "test-app": "meteor test --full-app --once --driver-package dispatch:mocha-phantomjs",
     "test-app-watch": "meteor test --full-app --driver-package practicalmeteor:mocha",
     "lint": "eslint .",
     "chimp-watch": "chimp --ddp=http://localhost:3000 --watch --mocha --path=tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "start": "meteor ${START_OPTS}",
+    "start": "meteor",
     "pretest": "npm run lint --silent",
     "test": "meteor test --once --driver-package dispatch:mocha-phantomjs",
     "test-watch": "meteor test --driver-package practicalmeteor:mocha",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "start": "meteor ${START_OPTS}",
     "pretest": "npm run lint --silent",
     "test": "meteor test --once --driver-package dispatch:mocha-phantomjs",
     "test-watch": "meteor test --driver-package practicalmeteor:mocha",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "pretest": "npm run lint --silent",
     "test": "meteor test --once --driver-package dispatch:mocha-phantomjs",
     "test-watch": "meteor test --driver-package practicalmeteor:mocha",
+    "test-app": "meteor test --full-app --once --driver-package dispatch:mocha-phantomjs",
     "test-app-watch": "meteor test --full-app --driver-package practicalmeteor:mocha",
     "lint": "eslint .",
     "chimp-watch": "chimp --ddp=http://localhost:3000 --watch --mocha --path=tests"


### PR DESCRIPTION
Standardizing entry points increases the approachability of bespoke software projects whether through internal APIs or command-line arguments.

Implementing [`npm start`](https://docs.npmjs.com/cli/start) works extremely well for sharing a common use case for running your Meteor app. And customization works great with environment variables as well.

```json
"scripts": {
  "start": "meteor ${START_OPTS}"
}
```

Bootstrapping also feels more natural since we're sticking to `npm`.

```sh
$ npm install
$ npm start
```

As noted in [npm-run-script](https://docs.npmjs.com/cli/run-script) you can pass additional flags to `meteor` through `npm` by appending `--`.

```sh
$ npm start -- --port 4000
```

Thoughts or opinions?