### PR TITLE
Use eslint-import-resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note that attempts will be made to keep the branches up to date but this isn't g
 ### Running the app
 
 ```bash
-npm install
+meteor npm install
 meteor
 ```
 
@@ -24,5 +24,5 @@ meteor
 To lint:
 
 ```bash
-npm run lint
+meteor npm run lint
 ```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "eslint": "^2.3.0",
     "eslint-config-airbnb": "^6.1.0",
+    "eslint-plugin-import": "^1.6.1",
     "eslint-plugin-meteor": "^3.0.1",
     "eslint-plugin-react": "^4.0.0"
   },
@@ -23,6 +24,7 @@
       "sourceType": "module"
     },
     "plugins": [
+      "import",
       "meteor"
     ],
     "extends": [
@@ -40,6 +42,9 @@
       "meteor/template-names": [
         0
       ]
+    },
+    "settings": {
+      "import/resolver": "meteor"
     }
   },
   "postcss": {


### PR DESCRIPTION
Changed the way lint is run (use the node_module version rather than
global).  Prefix the npm command with meteor to ensure we use Meteor's npm

Related PR for guide https://github.com/meteor/guide/pull/434

Based on
https://github.com/trajano/meteor-boilerplate/blob/master/.eslintrc.json