### PR TITLE
Modified validation options in ValidatedMethod definitions to referen…

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,6 +1,9 @@
 accounts-base@1.2.4
 accounts-password@1.1.6
-aldeed:collection2@2.5.0
+aldeed:collection2@2.9.1
+aldeed:collection2-core@1.1.1
+aldeed:schema-deny@1.0.1
+aldeed:schema-index@1.0.1
 aldeed:simple-schema@1.5.3
 aldeed:template-extension@4.0.0
 allow-deny@1.0.2

--- a/imports/api/lists/lists.js
+++ b/imports/api/lists/lists.js
@@ -35,6 +35,7 @@ Lists.deny({
 });
 
 Lists.schema = new SimpleSchema({
+  _id: { type: String, regEx: SimpleSchema.RegEx.Id },
   name: { type: String },
   incompleteCount: { type: Number, defaultValue: 0 },
   userId: { type: String, regEx: SimpleSchema.RegEx.Id, optional: true },

--- a/imports/api/lists/methods.js
+++ b/imports/api/lists/methods.js
@@ -7,8 +7,8 @@ import { _ } from 'meteor/underscore';
 import { Lists } from './lists.js';
 
 const LIST_ID_ONLY = new SimpleSchema({
-  listId: { type: String },
-}).validator();
+  listId: Lists.simpleSchema().schema('_id'),
+}).validator({ clean: true, filter: false });
 
 export const insert = new ValidatedMethod({
   name: 'lists.insert',
@@ -67,9 +67,9 @@ export const makePublic = new ValidatedMethod({
 export const updateName = new ValidatedMethod({
   name: 'lists.updateName',
   validate: new SimpleSchema({
-    listId: { type: String },
-    newName: { type: String },
-  }).validator(),
+    listId: Lists.simpleSchema().schema('_id'),
+    newName: Lists.simpleSchema().schema('name'),
+  }).validator({ clean: true, filter: false }),
   run({ listId, newName }) {
     const list = Lists.findOne(listId);
 

--- a/imports/api/todos/methods.js
+++ b/imports/api/todos/methods.js
@@ -9,10 +9,7 @@ import { Lists } from '../lists/lists.js';
 
 export const insert = new ValidatedMethod({
   name: 'todos.insert',
-  validate: new SimpleSchema({
-    listId: { type: String },
-    text: { type: String },
-  }).validator(),
+  validate: Todos.simpleSchema().pick(['listId', 'text']).validator({ clean: true, filter: false }),
   run({ listId, text }) {
     const list = Lists.findOne(listId);
 
@@ -35,9 +32,9 @@ export const insert = new ValidatedMethod({
 export const setCheckedStatus = new ValidatedMethod({
   name: 'todos.makeChecked',
   validate: new SimpleSchema({
-    todoId: { type: String },
-    newCheckedStatus: { type: Boolean },
-  }).validator(),
+    todoId: Todos.simpleSchema().schema('_id'),
+    newCheckedStatus: Todos.simpleSchema().schema('checked'),
+  }).validator({ clean: true, filter: false }),
   run({ todoId, newCheckedStatus }) {
     const todo = Todos.findOne(todoId);
 
@@ -60,9 +57,9 @@ export const setCheckedStatus = new ValidatedMethod({
 export const updateText = new ValidatedMethod({
   name: 'todos.updateText',
   validate: new SimpleSchema({
-    todoId: { type: String },
-    newText: { type: String },
-  }).validator(),
+    todoId: Todos.simpleSchema().schema('_id'),
+    newText: Todos.simpleSchema().schema('text'),
+  }).validator({ clean: true, filter: false }),
   run({ todoId, newText }) {
     // This is complex auth stuff - perhaps denormalizing a userId onto todos
     // would be correct here?
@@ -82,8 +79,8 @@ export const updateText = new ValidatedMethod({
 export const remove = new ValidatedMethod({
   name: 'todos.remove',
   validate: new SimpleSchema({
-    todoId: { type: String },
-  }).validator(),
+    todoId: Todos.simpleSchema().schema('_id'),
+  }).validator({ clean: true, filter: false }),
   run({ todoId }) {
     const todo = Todos.findOne(todoId);
 

--- a/imports/api/todos/todos.js
+++ b/imports/api/todos/todos.js
@@ -37,6 +37,10 @@ Todos.deny({
 });
 
 Todos.schema = new SimpleSchema({
+  _id: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
   listId: {
     type: String,
     regEx: SimpleSchema.RegEx.Id,


### PR DESCRIPTION
…ce the existing schema instead of creating new schemas from scratch. To support this, an _id field was added into the existing schemas. Also, aldeed:collection2 was updated from 2.5.0 to the latest 2.9.1 in order to support the usage of the _id field (ddp rate test failed due to false validation error).

Addresses issue #77 