### PR TITLE
re-enable unit and full-app tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,4 +24,6 @@ test:
   pre:
     - mkdir -p $CIRCLE_TEST_REPORTS/cucumber
   override:
+    - meteor npm test
+    - meteor npm run test-app
     - ./tests/acceptance_run


### PR DESCRIPTION
Tests were removed from CI in https://github.com/meteor/todos/pull/164 but they're working fine for me on master so we should add them back.

Open question is whether we should be running `meteor npm install` or `npm install`, but let's see if CI passes.