### PR TITLE
Wire up audit-argument-checks

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -73,3 +73,6 @@ practicalmeteor:mocha
 hwillson:stub-collections
 johanbrook:publication-collector
 shell-server
+
+# security
+audit-argument-checks

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -9,6 +9,7 @@ aldeed:template-extension@4.0.0
 allow-deny@1.0.5
 app-prod-security@0.0.0
 arillo:flow-router-helpers@0.5.2
+audit-argument-checks@1.0.7
 autoupdate@1.2.11
 babel-compiler@6.9.1
 babel-runtime@0.1.11

--- a/imports/api/todos/server/publications.js
+++ b/imports/api/todos/server/publications.js
@@ -6,11 +6,12 @@ import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import { Todos } from '../todos.js';
 import { Lists } from '../../lists/lists.js';
 
-Meteor.publishComposite('todos.inList', function todosInList(listId) {
+Meteor.publishComposite('todos.inList', function todosInList(params) {
   new SimpleSchema({
     listId: { type: String },
-  }).validate({ listId });
+  }).validate(params);
 
+  const { listId } = params;
   const userId = this.userId;
 
   return {

--- a/imports/api/todos/todos.tests.js
+++ b/imports/api/todos/todos.tests.js
@@ -55,42 +55,62 @@ if (Meteor.isServer) {
       describe('todos.inList', function () {
         it('sends all todos for a public list', function (done) {
           const collector = new PublicationCollector();
-          collector.collect('todos.inList', publicList._id, (collections) => {
-            chai.assert.equal(collections.Todos.length, 3);
-            done();
-          });
+          collector.collect(
+            'todos.inList',
+            { listId: publicList._id },
+            (collections) => {
+              chai.assert.equal(collections.Todos.length, 3);
+              done();
+            }
+          );
         });
 
         it('sends all todos for a public list when logged in', function (done) {
           const collector = new PublicationCollector({ userId });
-          collector.collect('todos.inList', publicList._id, (collections) => {
-            chai.assert.equal(collections.Todos.length, 3);
-            done();
-          });
+          collector.collect(
+            'todos.inList',
+            { listId: publicList._id },
+            (collections) => {
+              chai.assert.equal(collections.Todos.length, 3);
+              done();
+            }
+          );
         });
 
         it('sends all todos for a private list when logged in as owner', function (done) {
           const collector = new PublicationCollector({ userId });
-          collector.collect('todos.inList', privateList._id, (collections) => {
-            chai.assert.equal(collections.Todos.length, 3);
-            done();
-          });
+          collector.collect(
+            'todos.inList',
+            { listId: privateList._id },
+            (collections) => {
+              chai.assert.equal(collections.Todos.length, 3);
+              done();
+            }
+          );
         });
 
         it('sends no todos for a private list when not logged in', function (done) {
           const collector = new PublicationCollector();
-          collector.collect('todos.inList', privateList._id, (collections) => {
-            chai.assert.isUndefined(collections.Todos);
-            done();
-          });
+          collector.collect(
+            'todos.inList',
+            { listId: privateList._id },
+            (collections) => {
+              chai.assert.isUndefined(collections.Todos);
+              done();
+            }
+          );
         });
 
         it('sends no todos for a private list when logged in as another user', function (done) {
           const collector = new PublicationCollector({ userId: Random.id() });
-          collector.collect('todos.inList', privateList._id, (collections) => {
-            chai.assert.isUndefined(collections.Todos);
-            done();
-          });
+          collector.collect(
+            'todos.inList',
+            { listId: privateList._id },
+            (collections) => {
+              chai.assert.isUndefined(collections.Todos);
+              done();
+            }
+          );
         });
       });
     });

--- a/imports/ui/pages/lists-show-page.js
+++ b/imports/ui/pages/lists-show-page.js
@@ -14,7 +14,7 @@ Template.Lists_show_page.onCreated(function listsShowPageOnCreated() {
   this.getListId = () => FlowRouter.getParam('_id');
 
   this.autorun(() => {
-    this.subscribe('todos.inList', this.getListId());
+    this.subscribe('todos.inList', { listId: this.getListId() });
   });
 });
 


### PR DESCRIPTION
Hi guys - this relates to issue #61. In this PR I've wired `audit-argument-checks` up, and adjusted the code a bit to work around the issues that were happening when trying to use destructuring with check (via Simple Schema) and the `audit-argument-checks` package. I'll explain this more thoroughly in issue #61 in a few minutes. Thanks!