### PR TITLE
Adding full application i18n support with demonstration language

### DIFF
--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -13,7 +13,26 @@
     },
     "remove": {
       "accessDenied": "'You don't have permission to remove this list.'",
-      "lastPublicList": "Cannot delete the last public list."
+      "lastPublicList": "Cannot delete the last public list.",
+      "confirm": "Are you sure you want to delete the list"
+    },
+    "show": {
+      "cancel": "Cancel",
+      "showMenu": "Show Menu",
+      "selectAction": "Select an action",
+      "makePublic": "Make Public",
+      "makePrivate": "Make Private",
+      "delete": "Delete",
+      "makeListPublic": "Make list public",
+      "makeListPrivate": "Make list private",
+      "deleteList": "Delete list",
+      "typeToAdd": "Type to add new tasks",
+      "noTasks": "No tasks here",
+      "addAbove": "Add new tasks using the field above",
+      "loading": "Loading tasks..."
+    },
+    "insert": {
+      "list": "List"
     }
   },
   "todos": {
@@ -28,6 +47,30 @@
     },
     "remove": {
       "accessDenied": "Cannot remove todos in a private list that is not yours"
+    },
+    "item": {
+      "taskName": "Task name"
+    }
+  },
+  "useraccounts": {
+    "atTitle": {
+      "subtitle": "Signing in allows you to have private lists"
+    }
+  },
+  "layouts": {
+    "appBody": {
+      "logout": "Logout",
+      "login": "Sign In",
+      "join": "Join",
+      "newList": "New List",
+      "newListError": "Could not create list.",
+      "tryingToConnect": "Trying to connect",
+      "connectionIssue": "There seems to be a connection issue"
+    }
+  },
+  "pages": {
+    "appNotFound": {
+      "pageNotFound": "Page not found"
     }
   }
 }

--- a/i18n/fr.i18n.json
+++ b/i18n/fr.i18n.json
@@ -1,0 +1,76 @@
+{
+  "lists": {
+    "makePrivate": {
+      "notLoggedIn": "Doit être connecté pour réaliser des listes privées.",
+      "lastPublicList": "Vous ne pouvez pas faire la dernière liste publique privée."
+    },
+    "makePublic": {
+      "notLoggedIn": "Doit être connecté.",
+      "accessDenied": "Vous n'êtes pas autorisé à modifier cette liste."
+    },
+    "updateName": {
+      "accessDenied": "Vous n'êtes pas autorisé à modifier cette liste."
+    },
+    "remove": {
+      "accessDenied": "'Vous n'êtes pas autorisé à supprimer cette liste.'",
+      "lastPublicList": "Vous ne pouvez pas supprimer la dernière liste publique.",
+      "confirm": "Etes-vous sûr de vouloir supprimer la liste"
+    },
+    "show": {
+      "cancel": "Annuler",
+      "showMenu": "Afficher le menu",
+      "selectAction": "Sélectionnez une action",
+      "makePublic": "Rendre publique",
+      "makePrivate": "Rendre privé",
+      "delete": "Effacer",
+      "makeListPublic": "Ouvrir la liste pour le public",
+      "makeListPrivate": "Fermer la liste au public",
+      "deleteList": "Effacer la liste",
+      "typeToAdd": "Tapez pour ajouter de nouvelles tâches",
+      "noTasks": "Aucune tâche ici",
+      "addAbove": "Ajouter de nouvelles tâches ci-dessus",
+      "loading": "Chargement sauvé tâches..."
+    },
+    "insert": {
+      "list": "Liste"
+    }
+  },
+  "todos": {
+    "insert": {
+      "accessDenied": "Vous ne pouvez pas ajouter todo à une liste privée qui ne vous appartient pas"
+    },
+    "setCheckedStatus": {
+      "accessDenied": "Vous ne pouvez pas modifier todos dans une liste privée qui ne vous appartient pas"
+    },
+    "updateText": {
+      "accessDenied": "Vous ne pouvez pas modifier todos dans une liste privée qui ne vous appartient pas"
+    },
+    "remove": {
+      "accessDenied": "Vous ne pouvez pas supprimer todos dans une liste privée qui ne vous appartient pas"
+    },
+    "item": {
+      "taskName": "Nom de la tâche"
+    }
+  },
+  "useraccounts": {
+    "atTitle": {
+      "subtitle": "Connexion à vous permet d'avoir des listes privées"
+    }
+  },
+  "layouts": {
+    "appBody": {
+      "logout": "Se déconnecter",
+      "login": "Se connecter",
+      "join": "Joindre",
+      "newList": "Nouvelle liste",
+      "newListError": "La liste ne peut être créé.",
+      "tryingToConnect": "Tentative de connexion",
+      "connectionIssue": "Il semble y avoir un problème de connexion"
+    }
+  },
+  "pages": {
+    "appNotFound": {
+      "pageNotFound": "Page non trouvée"
+    }
+  }
+}

--- a/imports/api/lists/lists.js
+++ b/imports/api/lists/lists.js
@@ -1,19 +1,23 @@
 import { Mongo } from 'meteor/mongo';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import { Factory } from 'meteor/factory';
+import { TAPi18n } from 'meteor/tap:i18n';
+
 import { Todos } from '../todos/todos.js';
 
 class ListsCollection extends Mongo.Collection {
-  insert(list, callback) {
+  insert(list, callback, language = 'en') {
     const ourList = list;
     if (!ourList.name) {
+console.log(TAPi18n);
+      const defaultName = TAPi18n.__('lists.insert.list', null, language);
       let nextLetter = 'A';
-      ourList.name = `List ${nextLetter}`;
+      ourList.name = `${defaultName} ${nextLetter}`;
 
       while (this.findOne({ name: ourList.name })) {
         // not going to be too smart here, can go past Z
         nextLetter = String.fromCharCode(nextLetter.charCodeAt(0) + 1);
-        ourList.name = `List ${nextLetter}`;
+        ourList.name = `${defaultName} ${nextLetter}`;
       }
     }
 

--- a/imports/api/lists/lists.js
+++ b/imports/api/lists/lists.js
@@ -9,7 +9,6 @@ class ListsCollection extends Mongo.Collection {
   insert(list, callback, language = 'en') {
     const ourList = list;
     if (!ourList.name) {
-console.log(TAPi18n);
       const defaultName = TAPi18n.__('lists.insert.list', null, language);
       let nextLetter = 'A';
       ourList.name = `${defaultName} ${nextLetter}`;

--- a/imports/api/lists/lists.tests.js
+++ b/imports/api/lists/lists.tests.js
@@ -11,6 +11,7 @@ import { DDP } from 'meteor/ddp-client';
 import { Lists } from './lists.js';
 import { insert, makePublic, makePrivate, updateName, remove } from './methods.js';
 import { Todos } from '../todos/todos.js';
+import '../../../i18n/en.i18n.json';
 
 if (Meteor.isServer) {
   // eslint-disable-next-line import/no-unresolved
@@ -232,11 +233,11 @@ if (Meteor.isServer) {
           const connection = DDP.connect(Meteor.absoluteUrl());
 
           _.times(5, () => {
-            connection.call(insert.name, {});
+            connection.call(insert.name, { language: 'en' });
           });
 
           assert.throws(() => {
-            connection.call(insert.name, {});
+            connection.call(insert.name, { language: 'en' });
           }, Meteor.Error, /too-many-requests/);
 
           connection.disconnect();

--- a/imports/api/lists/methods.js
+++ b/imports/api/lists/methods.js
@@ -12,9 +12,13 @@ const LIST_ID_ONLY = new SimpleSchema({
 
 export const insert = new ValidatedMethod({
   name: 'lists.insert',
-  validate: new SimpleSchema({}).validator(),
-  run() {
-    return Lists.insert({});
+  validate: new SimpleSchema({
+    language: {
+      type: String,
+    },
+  }).validator(),
+  run({ language }) {
+    return Lists.insert({}, null, language);
   },
 });
 

--- a/imports/startup/both/useraccounts-configuration.js
+++ b/imports/startup/both/useraccounts-configuration.js
@@ -1,5 +1,4 @@
 import { AccountsTemplates } from 'meteor/useraccounts:core';
-import { TAPi18n } from 'meteor/tap:i18n';
 
 /**
  * The useraccounts package must be configured for both client and server to work properly.
@@ -8,16 +7,6 @@ import { TAPi18n } from 'meteor/tap:i18n';
 
 AccountsTemplates.configure({
   showForgotPasswordLink: true,
-  texts: {
-    errors: {
-      loginForbidden: TAPi18n.__('Incorrect username or password'),
-      pwdMismatch: TAPi18n.__('Passwords don\'t match'),
-    },
-    title: {
-      signIn: TAPi18n.__('Sign In'),
-      signUp: TAPi18n.__('Join'),
-    },
-  },
   defaultTemplate: 'Auth_page',
   defaultLayout: 'App_body',
   defaultContentRegion: 'main',

--- a/imports/ui/accounts/accounts-templates.html
+++ b/imports/ui/accounts/accounts-templates.html
@@ -36,7 +36,7 @@
 
 <template name="override-atTitle">
   <h1 class="title-auth">{{title}}</h1>
-  <p class="subtitle-auth">{{_ 'Signing in allows you to have private lists'}}</p>
+  <p class="subtitle-auth">{{_ 'useraccounts.atTitle.subtitle'}}</p>
 </template>
 
 <template name="override-atError">

--- a/imports/ui/components/lists-show.html
+++ b/imports/ui/components/lists-show.html
@@ -7,14 +7,20 @@
             <input type="text" name="name" value="{{name}}">
             <div class="nav-group right">
               <a href="#" class="js-cancel nav-item">
-                <span class="icon-close js-cancel" title={{_ 'Cancel'}}></span>
+                <span
+                  class="icon-close js-cancel"
+                  title={{_ 'lists.show.cancel'}}>
+                </span>
               </a>
             </div>
           </form>
         {{else}}
           <div class="nav-group">
             <a href="#" class="js-menu nav-item">
-              <span class="icon-list-unordered" title={{_ 'Show Menu'}}></span>
+              <span
+                class="icon-list-unordered"
+                title={{_ 'lists.show.showMenu'}}>
+              </span>
             </a>
           </div>
 
@@ -26,27 +32,38 @@
           <div class="nav-group right">
             <div class="nav-item options-mobile">
               <select class="list-edit">
-                <option disabled selected>{{_ 'Select an action'}}</option>
+                <option disabled selected>
+                  {{_ 'lists.show.selectAction'}}
+                </option>
                 {{#if list.userId}}
-                  <option value="public">{{_ 'Make Public'}}</option>
+                  <option value="public">{{_ 'lists.show.makePublic'}}</option>
                 {{else}}
-                  <option value="private">{{_ 'Make Private'}}</option>
+                  <option value="private">{{_ 'lists.show.makePrivate'}}</option>
                 {{/if}}
-                <option value="delete">{{_ 'Delete'}}</option>
+                <option value="delete">{{_ 'lists.show.delete'}}</option>
               </select>
               <span class="icon-cog"></span>
             </div>
             <div class="options-web">
               <a class="js-toggle-list-privacy nav-item">
                 {{#if list.userId}}
-                  <span class="icon-lock" title={{_ 'Make list public'}}></span>
+                  <span
+                    class="icon-lock"
+                    title={{_ 'lists.show.makeListPublic'}}>
+                  </span>
                 {{else}}
-                  <span class="icon-unlock" title={{_ 'Make list private'}}></span>
+                  <span
+                    class="icon-unlock"
+                    title={{_ 'lists.show.makeListPrivate'}}>
+                  </span>
                 {{/if}}
               </a>
 
               <a class="js-delete-list nav-item">
-                <span class="icon-trash" title={{_ 'Delete list'}}></span>
+                <span
+                  class="icon-trash"
+                  title={{_ 'lists.show.deleteList'}}>
+                </span>
               </a>
             </div>
           </div>
@@ -54,11 +71,13 @@
       {{/momentum}}
 
       <form class="js-todo-new todo-new input-symbol">
-        <input type="text" placeholder={{_ 'Type to add new tasks'}}>
+        <input
+          type="text"
+          placeholder={{_ 'lists.show.typeToAdd'}}
+        />
         <span class="icon-add js-todo-add"></span>
       </form>
     </nav>
-
 
     <div class="content-scrollable list-items">
       {{#if todosReady}}
@@ -66,14 +85,14 @@
           {{> Todos_item (todoArgs todo)}}
         {{else}}
           <div class="wrapper-message">
-            <div class="title-message">{{_ 'No tasks here'}}</div>
-            <div class="subtitle-message">{{_ 'Add new tasks using the field above'}}</div>
+            <div class="title-message">{{_ 'lists.show.noTasks'}}</div>
+            <div class="subtitle-message">{{_ 'lists.show.addAbove'}}</div>
           </div>
         {{/each}}
       {{else}}
-          <div class="wrapper-message">
-            <div class="title-message">{{_ 'Loading tasks...'}}</div>
-          </div>
+        <div class="wrapper-message">
+          <div class="title-message">{{_ 'lists.show.loading'}}</div>
+        </div>
       {{/if}}
     </div>
   </div>

--- a/imports/ui/components/lists-show.js
+++ b/imports/ui/components/lists-show.js
@@ -68,7 +68,7 @@ Template.Lists_show.onCreated(function listShowOnCreated() {
 
   this.deleteList = () => {
     const list = this.data.list();
-    const message = `${TAPi18n.__('Are you sure you want to delete the list')} ${list.name}?`;
+    const message = `${TAPi18n.__('lists.remove.confirm')} "${list.name}"?`;
 
     if (confirm(message)) { // eslint-disable-line no-alert
       remove.call({

--- a/imports/ui/components/todos-item.html
+++ b/imports/ui/components/todos-item.html
@@ -4,8 +4,10 @@
       <input type="checkbox" checked="{{todo.checked}}" name="checked">
       <span class="checkbox-custom"></span>
     </label>
-
-    <input type="text" value="{{todo.text}}" placeholder={{_ 'Task name'}}>
+    <input
+      type="text"
+      value="{{todo.text}}"
+      placeholder={{_ 'todos.item.taskName'}}>
     <a class="js-delete-item delete-item" href="#">
       <span class="icon-trash"></span>
     </a>

--- a/imports/ui/layouts/app-body.html
+++ b/imports/ui/layouts/app-body.html
@@ -2,6 +2,15 @@
   {{#HammerTouchArea gestureMap=templateGestures}}
     <div id="container" class="{{menuOpen}} {{cordova}}">
       <section id="menu">
+        <div class="language-toggle">
+          {{#each language in languages}}
+            {{#if isActiveLanguage language}}
+              <span class="active">{{language}}</span>
+            {{else}}
+              <a href="#" class="js-toggle-language">{{language}}</a>
+            {{/if}}
+          {{/each}}
+        </div>
         {{#if currentUser}}
           <div class="btns-group-vertical">
             <a href="#" class="js-user-menu btn-secondary">
@@ -14,20 +23,26 @@
               {{emailLocalPart}}
             </a>
             {{#if userMenuOpen}}
-              <a class="js-logout btn-secondary">{{_ 'Logout'}}</a>
+              <a class="js-logout btn-secondary">
+                {{_ 'layouts.appBody.logout'}}
+              </a>
             {{/if}}
           </div>
         {{else}}
           <div class="btns-group">
-            <a href="{{pathFor 'signin'}}" class="btn-secondary">{{_ 'Sign In'}}</a>
-            <a href="{{pathFor 'join'}}" class="btn-secondary">{{_ 'Join'}}</a>
+            <a href="{{pathFor 'signin'}}" class="btn-secondary">
+              {{_ 'layouts.appBody.login'}}
+            </a>
+            <a href="{{pathFor 'join'}}" class="btn-secondary">
+              {{_ 'layouts.appBody.join'}}
+            </a>
           </div>
         {{/if}}
 
         <div class="list-todos">
           <a class="js-new-list link-list-new">
             <span class="icon-plus"></span>
-            {{_ "New List"}}
+            {{_ 'layouts.appBody.newList'}}
           </a>
 
           {{#each list in lists}}
@@ -52,8 +67,12 @@
           <div class="notification">
             <span class="icon-sync"></span>
             <div class="meta">
-              <div class="title-notification">Trying to connect</div>
-              <div class="description">There seems to be a connection issue</div>
+              <div class="title-notification">
+                {{_ 'layouts.appBody.tryingToConnect'}}
+              </div>
+              <div class="description">
+                {{_ 'layouts.appBody.connectionIssue'}}
+              </div>
             </div>
           </div>
         </div>

--- a/imports/ui/layouts/app-body.js
+++ b/imports/ui/layouts/app-body.js
@@ -7,6 +7,9 @@ import { Template } from 'meteor/templating';
 import { ActiveRoute } from 'meteor/zimme:active-route';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { TAPi18n } from 'meteor/tap:i18n';
+import { T9n } from 'meteor/softwarerero:accounts-t9n';
+import { _ } from 'meteor/underscore';
+import { $ } from 'meteor/jquery';
 
 import { Lists } from '../../api/lists/lists.js';
 import { insert } from '../../api/lists/methods.js';
@@ -86,6 +89,12 @@ Template.App_body.helpers({
       instance.state.set('menuOpen', true);
     },
   },
+  languages() {
+    return _.keys(TAPi18n.getLanguages());
+  },
+  isActiveLanguage(language) {
+    return (TAPi18n.getLanguage() === language);
+  },
 });
 
 Template.App_body.events({
@@ -122,16 +131,22 @@ Template.App_body.events({
   },
 
   'click .js-new-list'() {
-    const listId = insert.call((err) => {
+    const listId = insert.call({ language: TAPi18n.getLanguage() }, (err) => {
       if (err) {
         // At this point, we have already redirected to the new list page, but
         // for some reason the list didn't get created. This should almost never
         // happen, but it's good to handle it anyway.
         FlowRouter.go('App.home');
-        alert(TAPi18n.__('Could not create list.')); // eslint-disable-line no-alert
+        alert(TAPi18n.__('layouts.appBody.newListError')); // eslint-disable-line no-alert
       }
     });
 
     FlowRouter.go('Lists.show', { _id: listId });
+  },
+
+  'click .js-toggle-language'(event) {
+    const language = $(event.target).html().trim();
+    T9n.setLanguage(language);
+    TAPi18n.setLanguage(language);
   },
 });

--- a/imports/ui/pages/app-not-found.html
+++ b/imports/ui/pages/app-not-found.html
@@ -2,13 +2,14 @@
   <div class="page not-found">
     <nav>
       <div class="nav-group">
-        <a href="#" class="js-menu nav-item"><span class="icon-list-unordered"></span></a>
+        <a href="#" class="js-menu nav-item">
+          <span class="icon-list-unordered"></span>
+        </a>
       </div>
     </nav>
-
     <div class="content-scrollable">
       <div class="wrapper-message">
-        <div class="title-message">{{_ 'Page not found'}}</div>
+        <div class="title-message">{{_ 'pages.appNotFound.pageNotFound'}}</div>
       </div>
     </div>
   </div>

--- a/imports/ui/stylesheets/menu.less
+++ b/imports/ui/stylesheets/menu.less
@@ -4,9 +4,20 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 
+  .language-toggle {
+    text-align: center;
+    margin-top: 1em;
+    font-size: .8rem;
+    .active {
+      border-bottom: 1px solid;
+      padding-bottom: 1px;
+      color: @color-secondary;
+    }
+  }
+
   .btns-group,
   .btns-group-vertical {
-    margin: 2em auto 2em;
+    margin: 1em auto 2em;
     width: 80%;
 
     .btn-secondary {


### PR DESCRIPTION
This PR is intended to help address issue #104. It includes:

- Removed the use of `TAPi18n` within the `AccountTemplate.configure` call, since useraccount translations are better handled by the `softwarerero:accounts-t9n` package (which was already in place).
- Converted the entire app over to use `TAPi18n`, for all language based strings (there were several strings missing from the previous i18n attempt).
- Created a French i18n file with all French translations.
- Wired up a sample language toggle for toggling application languages.

I'll add more details into issue #104 itself. Thanks!