### PR TITLE
Added shelljs devDependency to fix problematic eslint shelljs (react)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ To lint:
 ```bash
 meteor npm run lint
 ```
+

--- a/README.md
+++ b/README.md
@@ -18,4 +18,3 @@ To lint:
 ```bash
 meteor npm run lint
 ```
-

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ dependencies:
   override:
     - curl https://install.meteor.com | /bin/sh
     - npm install
+  post:
+    - rm -r ~/.gradle
 checkout:
   post:
     - git submodule update --init

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "eslint-plugin-meteor": "^4.0.0",
     "eslint-plugin-react": "^6.2.2",
     "meteor-node-stubs": "^0.2.3",
-    "react-addons-test-utils": "^15.3.1"
+    "react-addons-test-utils": "^15.3.1",
+    "shelljs": "^0.7.4"
   },
   "eslintConfig": {
     "parser": "babel-eslint",


### PR DESCRIPTION
Similar to PR #188, this is a workaround to address issue #107 for the `react` branch.