### PR TITLE
Fix tests

### DIFF
--- a/imports/api/lists/lists.tests.js
+++ b/imports/api/lists/lists.tests.js
@@ -49,7 +49,7 @@ if (Meteor.isServer) {
         it('sends all public lists', function (done) {
           const collector = new PublicationCollector();
           collector.collect('lists.public', (collections) => {
-            chai.assert.equal(collections.Lists.length, 3);
+            chai.assert.equal(collections.lists.length, 3);
             done();
           });
         });
@@ -59,7 +59,7 @@ if (Meteor.isServer) {
         it('sends all owned lists', function (done) {
           const collector = new PublicationCollector({ userId });
           collector.collect('lists.private', (collections) => {
-            chai.assert.equal(collections.Lists.length, 2);
+            chai.assert.equal(collections.lists.length, 2);
             done();
           });
         });

--- a/imports/api/todos/todos.tests.js
+++ b/imports/api/todos/todos.tests.js
@@ -59,7 +59,7 @@ if (Meteor.isServer) {
             'todos.inList',
             { listId: publicList._id },
             (collections) => {
-              chai.assert.equal(collections.Todos.length, 3);
+              chai.assert.equal(collections.todos.length, 3);
               done();
             }
           );
@@ -71,7 +71,7 @@ if (Meteor.isServer) {
             'todos.inList',
             { listId: publicList._id },
             (collections) => {
-              chai.assert.equal(collections.Todos.length, 3);
+              chai.assert.equal(collections.todos.length, 3);
               done();
             }
           );
@@ -83,7 +83,7 @@ if (Meteor.isServer) {
             'todos.inList',
             { listId: privateList._id },
             (collections) => {
-              chai.assert.equal(collections.Todos.length, 3);
+              chai.assert.equal(collections.todos.length, 3);
               done();
             }
           );
@@ -95,7 +95,7 @@ if (Meteor.isServer) {
             'todos.inList',
             { listId: privateList._id },
             (collections) => {
-              chai.assert.isUndefined(collections.Todos);
+              chai.assert.isUndefined(collections.todos);
               done();
             }
           );
@@ -107,7 +107,7 @@ if (Meteor.isServer) {
             'todos.inList',
             { listId: privateList._id },
             (collections) => {
-              chai.assert.isUndefined(collections.Todos);
+              chai.assert.isUndefined(collections.todos);
               done();
             }
           );


### PR DESCRIPTION
So at some point, the collections were renamed from `Lists` and `Todos` to `lists` and `todos`, but no one updated the tests to reflect this. With this update the tests (as run via `rm -Rf .meteor/local/plugin-cache; meteor npm test`) pass.

About that command: I seem to be hit hard by https://github.com/meteor/todos/issues/198 / https://github.com/DispatchMe/meteor-mocha-phantomjs/issues/33, and the solution in [this comment](https://github.com/meteor/todos/issues/198#issuecomment-264868959) was the only way I could get the tests to run. This should really be fixed. The CI server isn’t even running the real tests, it’s running a single test that looks like a stub.