### PR TITLE
Updating circle.yml to reflect CircleCI.com

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4.6.2
+    version: 5.2.0
 dependencies:
   cache_directories:
     - "~/.npm"
@@ -10,8 +10,8 @@ dependencies:
     - "./.meteor/local/bundler-cache"
     - "./.meteor/local/isopacks"
     - "./.meteor/local/plugin-cache"
-    - "/home/ubuntu/nvm/versions/node/v4.6.2/bin"
-    - "/home/ubuntu/nvm/versions/node/v4.6.2/lib/node_modules"
+    - "/home/ubuntu/nvm/versions/node/v5.2.0/bin"
+    - "/home/ubuntu/nvm/versions/node/v5.2.0/lib/node_modules"
   override:
     - ./.testing/upgrade_chrome_version.sh
     - ./.testing/cache_meteor.sh


### PR DESCRIPTION
I cloned the project and pushed my repo to CircleCI, it failed. Then I noticed the circle.yml that CircleCI.com reported was different than that in the repo. Updated my circle.yml to match CircleCI's copy, and it worked. So this file needs version bumped.