### PR TITLE
WIP: Making relative paths absolute

### DIFF
--- a/imports/api/generate-data.app-tests.js
+++ b/imports/api/generate-data.app-tests.js
@@ -6,7 +6,7 @@ import { resetDatabase } from 'meteor/xolvio:cleaner';
 import { Random } from 'meteor/random';
 import { _ } from 'meteor/underscore';
 
-import { denodeify } from '../utils/denodeify';
+import { denodeify } from '/imports/utils/denodeify';
 
 const createList = (userId) => {
   const list = Factory.create('list', { userId });

--- a/imports/api/lists/lists.js
+++ b/imports/api/lists/lists.js
@@ -3,7 +3,7 @@ import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import { Factory } from 'meteor/dburles:factory';
 import { TAPi18n } from 'meteor/tap:i18n';
 
-import { Todos } from '../todos/todos.js';
+import { Todos } from '/imports/api/todos/todos.js';
 
 class ListsCollection extends Mongo.Collection {
   insert(list, callback, language = 'en') {

--- a/imports/api/lists/server/publications.js
+++ b/imports/api/lists/server/publications.js
@@ -2,7 +2,7 @@
 
 import { Meteor } from 'meteor/meteor';
 
-import { Lists } from '../lists.js';
+import { Lists } from '/imports/api/lists/lists.js';
 
 Meteor.publish('lists.public', function listsPublic() {
   return Lists.find({

--- a/imports/api/todos/incompleteCountDenormalizer.js
+++ b/imports/api/todos/incompleteCountDenormalizer.js
@@ -2,7 +2,7 @@ import { _ } from 'meteor/underscore';
 import { check } from 'meteor/check';
 
 import { Todos } from './todos.js';
-import { Lists } from '../lists/lists.js';
+import { Lists } from '/imports/api/lists/lists.js';
 
 const incompleteCountDenormalizer = {
   _updateList(listId) {

--- a/imports/api/todos/methods.js
+++ b/imports/api/todos/methods.js
@@ -5,7 +5,7 @@ import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import { DDPRateLimiter } from 'meteor/ddp-rate-limiter';
 
 import { Todos } from './todos.js';
-import { Lists } from '../lists/lists.js';
+import { Lists } from '/imports/api/lists/lists.js';
 
 export const insert = new ValidatedMethod({
   name: 'todos.insert',

--- a/imports/api/todos/server/publications.js
+++ b/imports/api/todos/server/publications.js
@@ -3,8 +3,8 @@
 import { Meteor } from 'meteor/meteor';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 
-import { Todos } from '../todos.js';
-import { Lists } from '../../lists/lists.js';
+import { Todos } from '/imports/api/todos/todos.js';
+import { Lists } from '/imports/api/lists/lists.js';
 
 Meteor.publishComposite('todos.inList', function todosInList(params) {
   new SimpleSchema({

--- a/imports/api/todos/todos.js
+++ b/imports/api/todos/todos.js
@@ -4,7 +4,7 @@ import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import faker from 'faker';
 import incompleteCountDenormalizer from './incompleteCountDenormalizer.js';
 
-import { Lists } from '../lists/lists.js';
+import { Lists } from '/imports/api/lists/lists.js';
 
 class TodosCollection extends Mongo.Collection {
   insert(doc, callback) {

--- a/imports/startup/client/routes.app-test.js
+++ b/imports/startup/client/routes.app-test.js
@@ -8,10 +8,10 @@ import { assert } from 'meteor/practicalmeteor:chai';
 import { Promise } from 'meteor/promise';
 import { $ } from 'meteor/jquery';
 
-import { denodeify } from '../../utils/denodeify';
-import { generateData } from './../../api/generate-data.app-tests.js';
-import { Lists } from '../../api/lists/lists.js';
-import { Todos } from '../../api/todos/todos.js';
+import { denodeify } from '/imports/utils/denodeify';
+import { generateData } from '/imports/api/generate-data.app-tests.js';
+import { Lists } from '/imports/api/lists/lists.js';
+import { Todos } from '/imports/api/todos/todos.js';
 
 
 // Utility -- returns a promise which resolves when all subscriptions are done

--- a/imports/startup/client/routes.js
+++ b/imports/startup/client/routes.js
@@ -2,13 +2,13 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { BlazeLayout } from 'meteor/kadira:blaze-layout';
 
 // Import to load these templates
-import '../../ui/layouts/app-body.js';
-import '../../ui/pages/root-redirector.js';
-import '../../ui/pages/lists-show-page.js';
-import '../../ui/pages/app-not-found.js';
+import '/imports/ui/layouts/app-body.js';
+import '/imports/ui/pages/root-redirector.js';
+import '/imports/ui/pages/lists-show-page.js';
+import '/imports/ui/pages/app-not-found.js';
 
 // Import to override accounts templates
-import '../../ui/accounts/accounts-templates.js';
+import '/imports/ui/accounts/accounts-templates.js';
 
 FlowRouter.route('/lists/:_id', {
   name: 'Lists.show',

--- a/imports/startup/server/fixtures.js
+++ b/imports/startup/server/fixtures.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
-import { Lists } from '../../api/lists/lists.js';
-import { Todos } from '../../api/todos/todos.js';
+import { Lists } from '/imports/api/lists/lists.js';
+import { Todos } from '/imports/api/todos/todos.js';
 
 // if the database is empty on server start, create some sample data.
 Meteor.startup(() => {

--- a/imports/startup/server/register-api.js
+++ b/imports/startup/server/register-api.js
@@ -1,4 +1,4 @@
-import '../../api/lists/methods.js';
-import '../../api/lists/server/publications.js';
-import '../../api/todos/methods.js';
-import '../../api/todos/server/publications.js';
+import '/imports/api/lists/methods.js';
+import '/imports/api/lists/server/publications.js';
+import '/imports/api/todos/methods.js';
+import '/imports/api/todos/server/publications.js';

--- a/imports/ui/accounts/accounts-templates.less
+++ b/imports/ui/accounts/accounts-templates.less
@@ -1,4 +1,4 @@
-@import '../stylesheets/utils.less';
+@import '/imports/ui/stylesheets/utils.less';
 
 .page.auth {
   text-align: center;

--- a/imports/ui/components/client/lists-show.tests.js
+++ b/imports/ui/components/client/lists-show.tests.js
@@ -8,9 +8,9 @@ import { Template } from 'meteor/templating';
 import { _ } from 'meteor/underscore';
 import { $ } from 'meteor/jquery';
 
-import { withRenderedTemplate } from '../../test-helpers.js';
-import '../lists-show.js';
-import { Todos } from '../../../api/todos/todos.js';
+import { withRenderedTemplate } from '/imports/ui/test-helpers.js';
+import '/imports/ui/components/lists-show.js';
+import { Todos } from '/imports/api/todos/todos.js';
 
 
 describe('Lists_show', function () {

--- a/imports/ui/components/client/todos-item.tests.js
+++ b/imports/ui/components/client/todos-item.tests.js
@@ -5,11 +5,11 @@ import { Factory } from 'meteor/dburles:factory';
 import { chai } from 'meteor/practicalmeteor:chai';
 import { Template } from 'meteor/templating';
 import { $ } from 'meteor/jquery';
-import { Todos } from '../../../api/todos/todos';
+import { Todos } from '/imports/api/todos/todos';
 
 
-import { withRenderedTemplate } from '../../test-helpers.js';
-import '../todos-item.js';
+import { withRenderedTemplate } from '/imports/ui/test-helpers.js';
+import '/imports/ui/components/todos-item.js';
 
 describe('Todos_item', function () {
   beforeEach(function () {

--- a/imports/ui/components/lists-show.js
+++ b/imports/ui/components/lists-show.js
@@ -20,13 +20,13 @@ import {
   makePublic,
   makePrivate,
   remove,
-} from '../../api/lists/methods.js';
+} from '/imports/api/lists/methods.js';
 
 import {
   insert,
-} from '../../api/todos/methods.js';
+} from '/imports/api/todos/methods.js';
 
-import { displayError } from '../lib/errors.js';
+import { displayError } from '/imports/ui/lib/errors.js';
 
 Template.Lists_show.onCreated(function listShowOnCreated() {
   this.autorun(() => {

--- a/imports/ui/components/lists-show.less
+++ b/imports/ui/components/lists-show.less
@@ -1,4 +1,4 @@
-@import '../stylesheets/utils.less';
+@import '/imports/ui/stylesheets/utils.less';
 
 .page.lists-show {
   .content-scrollable {

--- a/imports/ui/components/loading.less
+++ b/imports/ui/components/loading.less
@@ -1,4 +1,4 @@
-@import '../stylesheets/utils.less';
+@import '/imports/ui/stylesheets/utils.less';
 
 .loading-app {
   .position(absolute, 50%, 50%, auto, auto, 50%);

--- a/imports/ui/components/todos-item.js
+++ b/imports/ui/components/todos-item.js
@@ -4,15 +4,15 @@ import { $ } from 'meteor/jquery';
 import { _ } from 'meteor/underscore';
 
 import './todos-item.html';
-import { Todos } from '../../api/todos/todos.js';
+import { Todos } from '/imports/api/todos/todos.js';
 
 import {
   setCheckedStatus,
   updateText,
   remove,
-} from '../../api/todos/methods.js';
+} from '/imports/api/todos/methods.js';
 
-import { displayError } from '../lib/errors.js';
+import { displayError } from '/imports/ui/lib/errors.js';
 
 Template.Todos_item.onCreated(function todosItemOnCreated() {
   this.autorun(() => {

--- a/imports/ui/layouts/app-body.js
+++ b/imports/ui/layouts/app-body.js
@@ -11,10 +11,10 @@ import { T9n } from 'meteor/softwarerero:accounts-t9n';
 import { _ } from 'meteor/underscore';
 import { $ } from 'meteor/jquery';
 
-import { Lists } from '../../api/lists/lists.js';
-import { insert } from '../../api/lists/methods.js';
+import { Lists } from '/imports/api/lists/lists.js';
+import { insert } from '/imports/api/lists/methods.js';
 
-import '../components/loading.js';
+import '/imports/ui/components/loading.js';
 import './app-body.html';
 
 const CONNECTION_ISSUE_TIMEOUT = 5000;

--- a/imports/ui/pages/app-not-found.less
+++ b/imports/ui/pages/app-not-found.less
@@ -1,4 +1,4 @@
-@import '../stylesheets/utils.less';
+@import '/imports/ui/stylesheets/utils.less';
 
 .page.not-found {
   .content-scrollable { background: @color-tertiary; }

--- a/imports/ui/pages/client/lists-show-page.tests.js
+++ b/imports/ui/pages/client/lists-show-page.tests.js
@@ -13,11 +13,12 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { sinon } from 'meteor/practicalmeteor:sinon';
 
 
-import { withRenderedTemplate } from '../../test-helpers.js';
-import '../lists-show-page.js';
+import { withRenderedTemplate } from '/imports/ui/test-helpers.js';
 
-import { Todos } from '../../../api/todos/todos.js';
-import { Lists } from '../../../api/lists/lists.js';
+import { Todos } from '/imports/api/todos/todos.js';
+import { Lists } from '/imports/api/lists/lists.js';
+
+import '../lists-show-page.js';
 
 describe('Lists_show_page', function () {
   const listId = Random.id();

--- a/imports/ui/pages/client/lists-show-page.tests.js
+++ b/imports/ui/pages/client/lists-show-page.tests.js
@@ -18,7 +18,7 @@ import { withRenderedTemplate } from '/imports/ui/test-helpers.js';
 import { Todos } from '/imports/api/todos/todos.js';
 import { Lists } from '/imports/api/lists/lists.js';
 
-import '../lists-show-page.js';
+import '/imports/ui/lists-show-page.js';
 
 describe('Lists_show_page', function () {
   const listId = Random.id();

--- a/imports/ui/pages/lists-show-page.js
+++ b/imports/ui/pages/lists-show-page.js
@@ -1,14 +1,14 @@
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
-import { Lists } from '../../api/lists/lists.js';
+import { Lists } from '/imports/api/lists/lists.js';
 
-import { listRenderHold } from '../launch-screen.js';
+import { listRenderHold } from '/imports/ui/launch-screen.js';
 import './lists-show-page.html';
 
 // Components used inside the template
 import './app-not-found.js';
-import '../components/lists-show.js';
+import '/imports/ui/components/lists-show.js';
 
 Template.Lists_show_page.onCreated(function listsShowPageOnCreated() {
   this.getListId = () => FlowRouter.getParam('_id');

--- a/imports/ui/pages/root-redirector.js
+++ b/imports/ui/pages/root-redirector.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
-import { Lists } from '../../api/lists/lists.js';
+import { Lists } from '/imports/api/lists/lists.js';
 
 import './root-redirector.html';
 


### PR DESCRIPTION
I see a lot of relative paths throughout the codebase, like `import { Todos } from '../../../api/todos/todos';` in todos-item.tests.js

It seems to me that `import { Todos } from '/imports/api/todos/todos';` is far more readable and reliable. You can move the file around without breaking things. Is there a reason for all these relative paths as opposed to absolute? If not, I will go ahead and fix the rest of the paths I can find and finish this PR.