### PR TITLE
[React] dont change route on login error

### DIFF
--- a/imports/ui/pages/AuthPageSignIn.jsx
+++ b/imports/ui/pages/AuthPageSignIn.jsx
@@ -36,8 +36,9 @@ export default class SignInPage extends BaseComponent {
         this.setState({
           errors: { none: err.reason },
         });
+      } else {
+          this.context.router.push('/');
       }
-      this.context.router.push('/');
     });
   }
 


### PR DESCRIPTION
In the react branch, when an error occurs in the login (for example, wrong user/password) the page changes anyway and there is no way to see the error message.