### PR TITLE
Dependency issues: Importing Nightmare (for the new dispatch:mocha) fails

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -76,3 +76,4 @@ dburles:factory
 
 # security
 audit-argument-checks@1.0.7
+dispatch:mocha

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,5 +1,6 @@
 accounts-base@1.2.14
 accounts-password@1.3.3
+aldeed:browser-tests@0.0.1
 aldeed:collection2@2.10.0
 aldeed:collection2-core@1.2.0
 aldeed:schema-deny@1.1.0
@@ -40,6 +41,7 @@ ddp-rate-limiter@1.0.6
 ddp-server@1.2.10
 deps@1.0.12
 diff-sequence@1.0.7
+dispatch:mocha@0.1.0
 dispatch:mocha-phantomjs@0.1.7
 dispatch:phantomjs-tests@0.0.5
 ecmascript@0.6.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM aedm/minimeteor

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test-app-watch": "meteor test --full-app --driver-package practicalmeteor:mocha",
     "test-watch-terminal": "TEST_WATCH=1 meteor test --driver-package dispatch:mocha-phantomjs",
     "test-app-watch-terminal": "TEST_WATCH=1 meteor test --full-app --driver-package dispatch:mocha-phantomjs",
+    "new-mocha": "TEST_BROWSER_DRIVER=nightmare meteor test --full-app --once --driver-package dispatch:mocha",
     "lint": "eslint ."
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-meteor": "^4.0.0",
     "eslint-plugin-react": "^6.2.2",
+    "nightmare": "^2.9.1",
     "shell-source": "^1.1.0",
     "shelljs": "^0.7.4"
   },

--- a/server/reproduction.nightmareerror.js
+++ b/server/reproduction.nightmareerror.js
@@ -1,0 +1,24 @@
+var Nightmare = require('nightmare');
+var nightmare = Nightmare({ show: true });
+
+
+Meteor.methods({
+  nightmare:function(){
+    console.log('start nightmare');
+    nightmare
+      .goto('https://duckduckgo.com')
+      .type('#search_form_input_homepage', 'github nightmare')
+      .click('#search_button_homepage')
+      .wait('#zero_click_wrapper .c-info__title a')
+      .evaluate(function () {
+        return document.querySelector('#zero_click_wrapper .c-info__title a').href;
+      })
+      .end()
+      .then(function (result) {
+        console.log(result);
+      })
+      .catch(function (error) {
+        console.error('Search failed:', error);
+      });
+  }
+});


### PR DESCRIPTION
@aldeed 's  new dispatch:mocha works great on newly-created blank apps. But after installing on Meteor Todos app as a reference, some issues come up.

Server tests work fine, as expected. But client tests with Nightmare seem to hang. It's failing silently with no errors in 'debug'.

Interestingly, if you try to use Nightmare in the Todo app server side you get `Error: Cannot find module './actions'` This does not happen on a newly created app, which runs fine.

Updating packages or meteor does not help.

This pull request only adds the npm script 'new-mocha', and also a reproduction file `./server/reproduction.nightmare.js` for discussion.

https://github.com/DispatchMe/meteor-mocha/issues/11
