### PR TITLE
Meteor 1.4.3.2; switch from phantom to nightmare; fixes #198

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -65,7 +65,6 @@ simple:rest
 
 # testing
 xolvio:cleaner
-dispatch:mocha-phantomjs
 practicalmeteor:chai
 practicalmeteor:sinon
 practicalmeteor:mocha
@@ -76,3 +75,4 @@ dburles:factory
 
 # security
 audit-argument-checks@1.0.7
+dispatch:mocha

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,5 +1,6 @@
 accounts-base@1.2.16
 accounts-password@1.3.5
+aldeed:browser-tests@0.1.0
 aldeed:collection2@2.10.0
 aldeed:collection2-core@1.2.0
 aldeed:schema-deny@1.1.0
@@ -11,7 +12,7 @@ app-prod-security@0.0.0
 arillo:flow-router-helpers@0.5.2
 audit-argument-checks@1.0.7
 autoupdate@1.3.12
-babel-compiler@6.18.1
+babel-compiler@6.18.2
 babel-runtime@1.0.1
 base64@1.0.10
 binary-heap@1.0.10
@@ -29,7 +30,7 @@ callback-hook@1.0.10
 cfs:http-methods@0.0.32
 check@1.2.5
 chriswessels:hammer@4.0.2
-coffeescript@1.11.1_4
+coffeescript@1.0.17
 crosswalk@1.7.1
 dburles:collection-helpers@1.1.0
 dburles:factory@1.1.0
@@ -40,12 +41,11 @@ ddp-rate-limiter@1.0.7
 ddp-server@1.3.14
 deps@1.0.12
 diff-sequence@1.0.7
-dispatch:mocha-phantomjs@0.1.9
-dispatch:phantomjs-tests@0.0.7
-ecmascript@0.7.2
+dispatch:mocha@0.3.0
+ecmascript@0.7.3
 ecmascript-runtime@0.3.15
 ejson@1.0.13
-email@1.2.0
+email@1.2.1
 es5-shim@4.6.15
 fastclick@1.0.13
 force-ssl@1.0.14
@@ -77,7 +77,7 @@ minifier-js@2.0.0
 minimongo@1.0.21
 mobile-experience@1.0.4
 mobile-status-bar@1.0.14
-modules@0.8.1
+modules@0.8.2
 modules-runtime@0.7.10
 mongo@1.1.16
 mongo-id@1.0.6

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "scripts": {
     "start": "meteor",
     "pretest": "npm run lint --silent",
-    "test": "meteor test --once --driver-package dispatch:mocha-phantomjs",
-    "test-app": "meteor test --full-app --once --driver-package dispatch:mocha-phantomjs",
+    "test": "TEST_BROWSER_DRIVER=nightmare meteor test --once --driver-package dispatch:mocha",
+    "test-app": "TEST_BROWSER_DRIVER=nightmare meteor test --full-app --once --driver-package dispatch:mocha",
     "test-watch": "meteor test --driver-package practicalmeteor:mocha",
     "test-app-watch": "meteor test --full-app --driver-package practicalmeteor:mocha",
-    "test-watch-terminal": "TEST_WATCH=1 meteor test --driver-package dispatch:mocha-phantomjs",
-    "test-app-watch-terminal": "TEST_WATCH=1 meteor test --full-app --driver-package dispatch:mocha-phantomjs",
+    "test-watch-terminal": "TEST_WATCH=1 TEST_BROWSER_DRIVER=nightmare meteor test --driver-package dispatch:mocha",
+    "test-app-watch-terminal": "TEST_WATCH=1 TEST_BROWSER_DRIVER=nightmare meteor test --full-app --driver-package dispatch:mocha",
     "lint": "eslint ."
   },
   "dependencies": {
@@ -24,6 +24,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-meteor": "^4.0.0",
     "eslint-plugin-react": "^6.2.2",
+    "nightmare": "^2.10.0",
     "shell-source": "^1.1.0",
     "shelljs": "^0.7.4"
   },


### PR DESCRIPTION
Looks like `dispatch:mocha-phantomjs` is deprecated:

https://forums.meteor.com/t/is-anyone-testing-their-meteor-apps/34027/17

The recommended package `dispatch:mocha` with nightmare is working for me. Would someone like to confirm it works for them too?