### PR TITLE
Add error-output

### DIFF
--- a/.testing/processes.js
+++ b/.testing/processes.js
@@ -13,7 +13,16 @@ module.exports = {
   start: function(opts, callback) {
     var proc = exec(
        opts.command,
-       opts.options
+       opts.options,
+       // catch errors that might otherwise NOT be shown in console
+       (error, stdout, stderr) => {
+         if (error) {
+           console.error(`exec error: ${error}`);
+           return;
+         }
+         console.log(`stdout: ${stdout}`);
+         console.log(`stderr: ${stderr}`);
+       },      
     );
     if (opts.waitForMessage) {
       proc.stdout.on('data', function waitForMessage(data) {


### PR DESCRIPTION
After wasting some hours I finally found out why my tests did NOT run on CI: it was due to the `maxBuffer` being to low. Only by adding the above lines I have found the error-message, which otherwise gets lost in nirvana