### PR TITLE
Code app in online environment

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+image:
+  file: Dockerfile
+tasks:
+- before: export ROOT_URL=$(gp url 3000)
+  init: meteor npm install && meteor lint
+  command: meteor
+ports:
+- port: 3000
+  onOpen: open-preview
+- port: 3001 # mongo db
+  onOpen: ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+RUN cd /home/gitpod && curl https://install.meteor.com/ | sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 [![Circle CI](https://circleci.com/gh/meteor/todos.svg?style=svg)](https://circleci.com/gh/meteor/todos)
 
-This is a Todos example app built on the principles described in the [Meteor Guide](http://guide.meteor.com/structure.html). 
+This is a Todos example app built on the principles described in the [Meteor Guide](http://guide.meteor.com/structure.html).
+
+Start coding on this project in Gitpod an online dev environment.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/meteor/todos)
 
 ## Versions
 


### PR DESCRIPTION
This PR adds config to run the Todo app in Gitpod a free online dev environment.
I was helping a user to use Meteor in Gitpod and thought you might be interested in this as well. It will allow anyone to start coding on the example app with a single click.

I configured it so that at start it first runs
 - `meteor npm install` followed by
 - `meteor`

Question: `meteor` builds the project which takes some time but opens the port immediately. Gitpod listens on ports and opens the preview panel, which then times out because meteor needs a lot of time fro building the app. Is there a command I could run that would do the build? `meteor build` didn't seem to do the same or I wasn't using the right parameters. Ideally I'd like to have a separate command that builds the app, so that `meteor run` would work immediately.
